### PR TITLE
Fix deploy script arguments

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -15,7 +15,12 @@ async function main() {
 
   const aed = await upgrades.deployProxy(
     AED,
-    [initialAdmin, paymentWallet], // initializer arguments
+    [
+      "Alsania Enhanced Domains", // ERC721 name
+      "AED",                       // ERC721 symbol
+      paymentWallet,               // fee collector
+      initialAdmin                 // admin
+    ],
     {
       initializer: "initialize",
       kind: "uups",


### PR DESCRIPTION
## Summary
- correct the initialization arguments for `deployProxy` in deployment script

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68701fa0975c83218f3445f09496778c